### PR TITLE
add hosting job

### DIFF
--- a/sia-ant/job_host.go
+++ b/sia-ant/job_host.go
@@ -41,7 +41,6 @@ func (j *JobRunner) jobHost() {
 			break
 		}
 	}
-
 	if !success {
 		log.Printf("[%v jobHost ERROR]: timeout: could not mine enough currency after 5 minutes\n", j.siaDirectory)
 		return


### PR DESCRIPTION
This PR adds job_host, which implements a basic, long running hosting job.  It mines at least 50,000 SC (for collateral), announces, sets accepting contracts, and polls the api, printing `INFO` messages to the log with its financial metrics.  If `StorageRevenue` decreases, an `ERROR` is printed.
