### PR TITLE
Bind RPC and Host addresses to all interfaces by default

### DIFF
--- a/sia-antfarm/ant_test.go
+++ b/sia-antfarm/ant_test.go
@@ -156,12 +156,12 @@ func TestConnectAnts(t *testing.T) {
 	for _, ant := range ants[1:] {
 		hasAddr := false
 		for _, peer := range gatewayInfo.Peers {
-			if fmt.Sprintf("%s", peer.NetAddress) == ant.rpcaddr {
+			if fmt.Sprintf("%s", peer.NetAddress) == "127.0.0.1"+ant.rpcaddr {
 				hasAddr = true
 			}
 		}
 		if !hasAddr {
-			t.Fatalf("the central ant is missing %v", ant.rpcaddr)
+			t.Fatalf("the central ant is missing %v", "127.0.0.1"+ant.rpcaddr)
 		}
 	}
 }


### PR DESCRIPTION
This PR changes getAddrs to return an available all-interfaces bind address (`:foo`).  This makes the RPC and Host addresses bind to all interfaces by default, the desired behavior.  API addresses are still bound to localhost by manually concatenating the returned value from `getAddrs` with `localhost`
