### PR TITLE
remove stray j.tg.Done from mining job

### DIFF
--- a/sia-ant/job_mining.go
+++ b/sia-ant/job_mining.go
@@ -49,7 +49,6 @@ func (j *JobRunner) blockMining() {
 		if walletInfo.ConfirmedSiacoinBalance.Cmp(types.ZeroCurrency) > 0 {
 			// We have mined a block and now have money, continue
 			success = true
-			j.tg.Done()
 			break
 		}
 	}


### PR DESCRIPTION
There was a stray j.tg.Done() in the mining job, that didn't have a corresponding j.tg.Add().
