### PR TITLE
escape percent character to prevent being used as printf verb

### DIFF
--- a/sia-ant/job_renter.go
+++ b/sia-ant/job_renter.go
@@ -372,7 +372,7 @@ func (r *renterJob) upload() error {
 	if uploadProgress < 100 {
 		return fmt.Errorf("file with siapath %v could not be fully uploaded after 10 minutes.  progress reached: %v", siapath, uploadProgress)
 	}
-	log.Printf("[INFO] [renter] [%v]: file has been successfully uploaded to 100%.\n", r.jr.siaDirectory)
+	log.Printf("[INFO] [renter] [%v]: file has been successfully uploaded to 100%%.\n", r.jr.siaDirectory)
 	return nil
 }
 


### PR DESCRIPTION
There was an unescaped '%' in one of the logging statements in the renter job, being read as a printf verb.  This PR adds an extra '%' to properly escape this character.