### PR TITLE
add multi-antfarm support

### DIFF
--- a/sia-antfarm/ant.go
+++ b/sia-antfarm/ant.go
@@ -65,7 +65,7 @@ func connectAnts(ants ...*Ant) error {
 	return nil
 }
 
-// antConsensusGroups iterates through all of the ants known to the ant farm
+// antConsensusGroups iterates through all of the ants known to the antFarm
 // and returns the different consensus groups that have been formed between the
 // ants.
 //

--- a/sia-antfarm/ant.go
+++ b/sia-antfarm/ant.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -51,7 +52,12 @@ func connectAnts(ants ...*Ant) error {
 	targetAnt := ants[0]
 	c := api.NewClient(targetAnt.APIAddr, "")
 	for _, ant := range ants[1:] {
-		err := c.Post(fmt.Sprintf("/gateway/connect/%v", "127.0.0.1"+ant.RPCAddr), "", nil)
+		connectQuery := fmt.Sprintf("/gateway/connect/%v", ant.RPCAddr)
+		addr := modules.NetAddress(ant.RPCAddr)
+		if addr.Host() == "" {
+			connectQuery = fmt.Sprintf("/gateway/connect/%v", "127.0.0.1"+ant.RPCAddr)
+		}
+		err := c.Post(connectQuery, "", nil)
 		if err != nil {
 			return err
 		}
@@ -138,7 +144,6 @@ func NewAnt(config AntConfig) (*Ant, error) {
 	// temporary directory.
 	siadir := config.SiaDirectory
 	if siadir == "" {
-		os.Mkdir("./antfarm-data", 0700)
 		tempdir, err := ioutil.TempDir("./antfarm-data", "ant")
 		if err != nil {
 			return nil, err

--- a/sia-antfarm/ant_test.go
+++ b/sia-antfarm/ant_test.go
@@ -209,7 +209,7 @@ func TestAntConsensusGroups(t *testing.T) {
 	ants = append(ants, otherAnt)
 
 	// Wait for the other ant to mine a few blocks
-	time.Sleep(time.Second * 10)
+	time.Sleep(time.Second * 30)
 
 	groups, err = antConsensusGroups(ants...)
 	if err != nil {

--- a/sia-antfarm/ant_test.go
+++ b/sia-antfarm/ant_test.go
@@ -37,7 +37,7 @@ func TestStartAnts(t *testing.T) {
 
 	// verify each ant has a reachable api
 	for _, ant := range ants {
-		c := api.NewClient(ant.apiaddr, "")
+		c := api.NewClient(ant.APIAddr, "")
 		if err := c.Get("/consensus", nil); err != nil {
 			t.Fatal(err)
 		}
@@ -148,7 +148,7 @@ func TestConnectAnts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := api.NewClient(ants[0].apiaddr, "")
+	c := api.NewClient(ants[0].APIAddr, "")
 	var gatewayInfo api.GatewayGET
 	err = c.Get("/gateway", &gatewayInfo)
 	if err != nil {
@@ -158,12 +158,12 @@ func TestConnectAnts(t *testing.T) {
 	for _, ant := range ants[1:] {
 		hasAddr := false
 		for _, peer := range gatewayInfo.Peers {
-			if fmt.Sprintf("%s", peer.NetAddress) == "127.0.0.1"+ant.rpcaddr {
+			if fmt.Sprintf("%s", peer.NetAddress) == "127.0.0.1"+ant.RPCAddr {
 				hasAddr = true
 			}
 		}
 		if !hasAddr {
-			t.Fatalf("the central ant is missing %v", "127.0.0.1"+ant.rpcaddr)
+			t.Fatalf("the central ant is missing %v", "127.0.0.1"+ant.RPCAddr)
 		}
 	}
 }

--- a/sia-antfarm/antfarm.go
+++ b/sia-antfarm/antfarm.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"log"
+	"os"
+	"sync"
+	"time"
+)
+
+type (
+	// AntfarmConfig contains the fields to parse and use to create a sia-antfarm.
+	AntfarmConfig struct {
+		AntConfigs    []AntConfig
+		AutoConnect   bool
+		ExternalFarms []string
+	}
+
+	// antFarm defines the 'antfarm' type. antFarm orchestrates a collection of
+	// ants and provides an API server to interact with them.
+	antFarm struct {
+		wg   sync.WaitGroup
+		ants []*Ant
+	}
+)
+
+// createAntfarm creates a new antFarm given the supplied AntfarmConfig
+func createAntfarm(config AntfarmConfig) (*antFarm, error) {
+	// clear old antfarm data before creating an antfarm
+	os.RemoveAll("./antfarm-data")
+
+	farm := &antFarm{}
+
+	// start up each ant process with its jobs
+	ants, err := startAnts(config.AntConfigs...)
+	if err != nil {
+		return nil, err
+	}
+	farm.ants = ants
+	farm.wg.Add(len(ants))
+	go func() {
+		for _, ant := range ants {
+			ant.Wait()
+			farm.wg.Done()
+		}
+	}()
+
+	// if the AutoConnect flag is set, use connectAnts to bootstrap the network.
+	if config.AutoConnect {
+		if err = connectAnts(ants...); err != nil {
+			return nil, err
+		}
+	}
+
+	go farm.permanentSyncMonitor()
+
+	return farm, nil
+}
+
+// permanentSyncMonitor checks that all ants in the antFarm are on the same
+// blockchain.
+func (af *antFarm) permanentSyncMonitor() {
+	// Give 30 seconds for everything to start up.
+	time.Sleep(time.Second * 30)
+
+	// Every 20 seconds, list all consensus groups.
+	for {
+		time.Sleep(time.Second * 20)
+		groups, err := antConsensusGroups(af.ants...)
+		if err != nil {
+			log.Println("error checking sync status of antfarm: ", err)
+			continue
+		}
+		if len(groups) == 1 {
+			log.Println("Ants are synchronized.")
+		} else {
+			log.Println("Ants split into multiple groups, displaying")
+			for i, group := range groups {
+				if i != 0 {
+					log.Println()
+				}
+				log.Println("Group ", i+1)
+				for _, ant := range group {
+					log.Println(ant.apiaddr)
+				}
+			}
+		}
+	}
+}
+
+// Close signals all the ants to stop and waits for them to return.
+func (af *antFarm) Close() error {
+	for _, ant := range af.ants {
+		ant.Process.Signal(os.Interrupt)
+	}
+	af.wg.Wait()
+	return nil
+}

--- a/sia-antfarm/antfarm.go
+++ b/sia-antfarm/antfarm.go
@@ -32,10 +32,6 @@ type (
 		ants        []*Ant
 		router      *httprouter.Router
 	}
-
-	antsGET struct {
-		Ants []*Ant
-	}
 )
 
 // createAntfarm creates a new antFarm given the supplied AntfarmConfig
@@ -104,12 +100,12 @@ func (af *antFarm) connectExternalAntfarm(externalAddress string) error {
 	}
 	defer res.Body.Close()
 
-	var ag antsGET
-	err = json.NewDecoder(res.Body).Decode(&ag)
+	var externalAnts []*Ant
+	err = json.NewDecoder(res.Body).Decode(&externalAnts)
 	if err != nil {
 		return err
 	}
-	ants := append(af.ants, ag.Ants...)
+	ants := append(af.ants, externalAnts...)
 	return connectAnts(ants...)
 }
 
@@ -155,7 +151,7 @@ func (af *antFarm) permanentSyncMonitor() {
 // getAnts is a http handler that returns the ants currently running on the
 // antfarm.
 func (af *antFarm) getAnts(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	err := json.NewEncoder(w).Encode(antsGET{Ants: af.ants})
+	err := json.NewEncoder(w).Encode(af.ants)
 	if err != nil {
 		http.Error(w, "error encoding ants", 500)
 	}

--- a/sia-antfarm/antfarm_test.go
+++ b/sia-antfarm/antfarm_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
 	"testing"
 )
 
@@ -11,6 +13,7 @@ func TestNewAntfarm(t *testing.T) {
 	}
 
 	config := AntfarmConfig{
+		ListenAddress: "localhost:31337",
 		AntConfigs: []AntConfig{
 			{
 				RPCAddr: "localhost:3337",
@@ -26,4 +29,24 @@ func TestNewAntfarm(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer antfarm.Close()
+
+	go antfarm.ServeAPI()
+
+	res, err := http.DefaultClient.Get("http://localhost:31337/ants")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	var ag antsGET
+	err = json.NewDecoder(res.Body).Decode(&ag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ag.Ants) != len(config.AntConfigs) {
+		t.Fatal("expected /ants to return the correct number of ants")
+	}
+	if ag.Ants[0].RPCAddr != config.AntConfigs[0].RPCAddr {
+		t.Fatal("expected /ants to return the correct rpc address")
+	}
 }

--- a/sia-antfarm/antfarm_test.go
+++ b/sia-antfarm/antfarm_test.go
@@ -42,15 +42,15 @@ func TestNewAntfarm(t *testing.T) {
 	}
 	defer res.Body.Close()
 
-	var ag antsGET
-	err = json.NewDecoder(res.Body).Decode(&ag)
+	var ants []*Ant
+	err = json.NewDecoder(res.Body).Decode(&ants)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ag.Ants) != len(config.AntConfigs) {
+	if len(ants) != len(config.AntConfigs) {
 		t.Fatal("expected /ants to return the correct number of ants")
 	}
-	if ag.Ants[0].RPCAddr != config.AntConfigs[0].RPCAddr {
+	if ants[0].RPCAddr != config.AntConfigs[0].RPCAddr {
 		t.Fatal("expected /ants to return the correct rpc address")
 	}
 }

--- a/sia-antfarm/antfarm_test.go
+++ b/sia-antfarm/antfarm_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+)
+
+// verify that createAntfarm() creates a new antfarm correctly.
+func TestNewAntfarm(t *testing.T) {
+	config := AntfarmConfig{
+		AntConfigs: []AntConfig{
+			{
+				RPCAddr: "localhost:3337",
+				Jobs: []string{
+					"gateway",
+				},
+			},
+		},
+	}
+
+	antfarm, err := createAntfarm(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer antfarm.Close()
+}

--- a/sia-antfarm/antfarm_test.go
+++ b/sia-antfarm/antfarm_test.go
@@ -6,6 +6,10 @@ import (
 
 // verify that createAntfarm() creates a new antfarm correctly.
 func TestNewAntfarm(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	config := AntfarmConfig{
 		AntConfigs: []AntConfig{
 			{

--- a/sia-antfarm/main.go
+++ b/sia-antfarm/main.go
@@ -4,11 +4,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
-	"sync"
-	"time"
 )
 
 // AntConfig contains fields to pass to a sia-ant job runner.
@@ -18,12 +15,6 @@ type AntConfig struct {
 	HostAddr     string `json:",omitempty"`
 	SiaDirectory string `json:",omitempty"`
 	Jobs         []string
-}
-
-// AntfarmConfig contains the fields to parse and use to create a sia-antfarm.
-type AntfarmConfig struct {
-	AntConfigs  []AntConfig
-	AutoConnect bool
 }
 
 func main() {
@@ -45,75 +36,17 @@ func main() {
 	}
 	f.Close()
 
-	// Clear out the old antfarm data before starting the new antfarm.
-	os.RemoveAll("./antfarm-data")
-
-	// Start each sia-ant process with its assigned jobs from the config file.
-	ants, err := startAnts(antfarmConfig.AntConfigs...)
+	farm, err := createAntfarm(antfarmConfig)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error starting ants: %v\n", err)
+		fmt.Fprintf(os.Stderr, "error creating antfarm: %v\n", err)
 		os.Exit(1)
 	}
-
-	// Wait for every ant process to exit before exiting antfarm
-	var wg sync.WaitGroup
-	wg.Add(len(ants))
-	go func() {
-		for _, ant := range ants {
-			ant.Wait()
-			wg.Done()
-		}
-	}()
-
-	if antfarmConfig.AutoConnect {
-		if err = connectAnts(ants...); err != nil {
-			fmt.Fprintf(os.Stderr, "error connecting ant: %v\n", err)
-		}
-	}
-
-	// Spawn a thread that checks that all ants in the antfarm are on the same
-	// blockchain every 20 seconds.
-	go func() {
-		// Give 30 seconds for everything to start up.
-		time.Sleep(time.Second * 30)
-
-		// Every 20 seconds, list all consensus groups.
-		for {
-			time.Sleep(time.Second * 20)
-			groups, err := antConsensusGroups(ants...)
-			if err != nil {
-				log.Println("error checking sync status of antfarm: ", err)
-				continue
-			}
-			if len(groups) == 1 {
-				log.Println("Ants are synchronized.")
-			} else {
-				log.Println("Ants split into multiple groups, displaying")
-				for i, group := range groups {
-					if i != 0 {
-						log.Println()
-					}
-					log.Println("Group ", i+1)
-					for _, ant := range group {
-						log.Println(ant.apiaddr)
-					}
-				}
-			}
-		}
-	}()
+	defer farm.Close()
 
 	sigchan := make(chan os.Signal, 1)
 	signal.Notify(sigchan, os.Interrupt)
 
-	go func() {
-		<-sigchan
-		fmt.Println("Caught quit signal, stopping all ants...")
-		for _, cmd := range ants {
-			cmd.Process.Signal(os.Interrupt)
-		}
-	}()
-
 	fmt.Printf("Finished.  Running sia-antfarm with %v ants.\n", len(antfarmConfig.AntConfigs))
-
-	wg.Wait()
+	<-sigchan
+	fmt.Println("Caught quit signal, quitting...")
 }

--- a/sia-antfarm/main.go
+++ b/sia-antfarm/main.go
@@ -42,6 +42,7 @@ func main() {
 		os.Exit(1)
 	}
 	defer farm.Close()
+	go farm.ServeAPI()
 
 	sigchan := make(chan os.Signal, 1)
 	signal.Notify(sigchan, os.Interrupt)


### PR DESCRIPTION
this PR adds a HTTP API for sia-antfarm, and adds another optional flag to the config manifest: `ExternalAntfarms`.  This is an array of api addresses representing external antfarms that should be connected to on startup.  Currently, this just means `/gateway/connect` is called on each node in the antfarm to connect them manually to a node on the external antfarm.

Note that in most cases, RPC addresses should be manually supplied in the config to avoid connectivity problems.