### PR TITLE
use `--flag=` pattern for cross-platform

### DIFF
--- a/sia-ant/main.go
+++ b/sia-ant/main.go
@@ -18,7 +18,7 @@ import (
 // pointer to siad's os.Cmd object is returned.  The data directory `datadir`
 // is passed as siad's `--sia-directory`.
 func NewSiad(siadPath string, datadir string, apiAddr string, rpcAddr string, hostAddr string) (*exec.Cmd, error) {
-	cmd := exec.Command(siadPath, "--no-bootstrap", "--sia-directory", datadir, "--api-addr", apiAddr, "--rpc-addr", rpcAddr, "--host-addr", hostAddr)
+	cmd := exec.Command(siadPath, "--no-bootstrap", "--sia-directory="+datadir, "--api-addr="+apiAddr, "--rpc-addr="+rpcAddr, "--host-addr="+hostAddr)
 	if err := cmd.Start(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
testing on Windows revealed that command line args must be passed using the `--flag=val` pattern, instead of `--flag val`.