### PR TITLE
check for siad exit in waitForAPI

### DIFF
--- a/sia-ant/main.go
+++ b/sia-ant/main.go
@@ -40,7 +40,8 @@ func NewSiad(siadPath string, datadir string, apiAddr string, rpcAddr string, ho
 	return cmd, nil
 }
 
-// stopSiad tries to stop the siad running at `apiAddr`, issuing a kill to its `process` after a timeout.
+// stopSiad tries to stop the siad running at `apiAddr`, issuing a kill to its
+// `process` after a timeout.
 func stopSiad(apiAddr string, process *os.Process) {
 	if err := api.NewClient(apiAddr, "").Get("/daemon/stop", nil); err != nil {
 		process.Kill()

--- a/sia-ant/main.go
+++ b/sia-ant/main.go
@@ -78,7 +78,7 @@ func waitForAPI(apiAddr string, siad *exec.Cmd) error {
 		}
 		select {
 		case err := <-exitchan:
-			return errors.New("siad exited unexpectedly while waiting for api, exited with error: " + err.Error())
+			return fmt.Errorf("siad exited unexpectedly while waiting for api, exited with error: %v\n", err)
 		default:
 			if err := c.Get("/consensus", nil); err == nil {
 				success = true

--- a/sia-ant/main_test.go
+++ b/sia-ant/main_test.go
@@ -31,4 +31,11 @@ func TestNewSiad(t *testing.T) {
 	if err := c.Get("/consensus", nil); err != nil {
 		t.Error(err)
 	}
+	siad.Process.Kill()
+
+	// verify that NewSiad returns an error given invalid args
+	_, err = NewSiad("siad", datadir, "this_is_an_invalid_addres:1000000", "localhost:0", "localhost:0")
+	if err == nil {
+		t.Fatal("expected newsiad to return an error with invalid args")
+	}
 }


### PR DESCRIPTION
this PR fixes the issue where if `siad` exits unexpectedly while waiting for the API to become available, `sia-ant` will timeout after 5 minutes of waiting instead of detecting the error and returning immediately.