### PR TITLE
add balance maintainer job

### DIFF
--- a/ant/ant.go
+++ b/ant/ant.go
@@ -35,11 +35,19 @@ type Ant struct {
 
 // New creates a new Ant using the configuration passed through `config`.
 func New(config AntConfig) (*Ant, error) {
+	var err error
 	// Construct the ant's Siad instance
 	siad, err := newSiad(config.SiadPath, config.SiaDirectory, config.APIAddr, config.RPCAddr, config.HostAddr)
 	if err != nil {
 		return nil, err
 	}
+
+	// Ensure siad is always stopped if an error is returned.
+	defer func() {
+		if err != nil {
+			stopSiad(config.APIAddr, siad.Process)
+		}
+	}()
 
 	j, err := newJobRunner(config.APIAddr, "", config.SiaDirectory)
 	if err != nil {
@@ -49,7 +57,7 @@ func New(config AntConfig) (*Ant, error) {
 	for _, job := range config.Jobs {
 		switch job {
 		case "miner":
-			go j.blockMining(types.SiacoinPrecision.Mul64(config.DesiredCurrency))
+			go j.blockMining()
 		case "host":
 			go j.jobHost()
 		case "renter":
@@ -57,6 +65,10 @@ func New(config AntConfig) (*Ant, error) {
 		case "gateway":
 			go j.gatewayConnectability()
 		}
+	}
+
+	if config.DesiredCurrency != 0 {
+		go j.balanceMaintainer(types.SiacoinPrecision.Mul64(config.DesiredCurrency))
 	}
 
 	return &Ant{

--- a/ant/ant.go
+++ b/ant/ant.go
@@ -9,12 +9,13 @@ import (
 // AntConfig represents a configuration object passed to New(), used to
 // configure a newly created Sia Ant.
 type AntConfig struct {
-	APIAddr      string `json:",omitempty"`
-	RPCAddr      string `json:",omitempty"`
-	HostAddr     string `json:",omitempty"`
-	SiaDirectory string `json:",omitempty"`
-	SiadPath     string
-	Jobs         []string
+	APIAddr         string `json:",omitempty"`
+	RPCAddr         string `json:",omitempty"`
+	HostAddr        string `json:",omitempty"`
+	SiaDirectory    string `json:",omitempty"`
+	SiadPath        string
+	Jobs            []string
+	DesiredCurrency string
 }
 
 // An Ant is a Sia Client programmed with network user stories. It executes
@@ -48,7 +49,7 @@ func New(config AntConfig) (*Ant, error) {
 	for _, job := range config.Jobs {
 		switch job {
 		case "miner":
-			go j.blockMining()
+			go j.blockMining(config.DesiredCurrency)
 		case "host":
 			go j.jobHost()
 		case "renter":

--- a/ant/ant.go
+++ b/ant/ant.go
@@ -15,7 +15,7 @@ type AntConfig struct {
 	SiaDirectory    string `json:",omitempty"`
 	SiadPath        string
 	Jobs            []string
-	DesiredCurrency string
+	DesiredCurrency uint64
 }
 
 // An Ant is a Sia Client programmed with network user stories. It executes
@@ -49,7 +49,7 @@ func New(config AntConfig) (*Ant, error) {
 	for _, job := range config.Jobs {
 		switch job {
 		case "miner":
-			go j.blockMining(config.DesiredCurrency)
+			go j.blockMining(types.SiacoinPrecision.Mul64(config.DesiredCurrency))
 		case "host":
 			go j.jobHost()
 		case "renter":

--- a/ant/job_balancemaintainer.go
+++ b/ant/job_balancemaintainer.go
@@ -1,0 +1,59 @@
+package ant
+
+import (
+	"log"
+	"time"
+
+	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// balanceMaintainer mines when the balance is below desiredBalance. The miner
+// is stopped if the balance exceeds the desired balance.
+func (j *jobRunner) balanceMaintainer(desiredBalance types.Currency) {
+	j.tg.Add()
+	defer j.tg.Done()
+
+	minerRunning := true
+	err := j.client.Get("/miner/start", nil)
+	if err != nil {
+		log.Printf("[%v balanceMaintainer ERROR]: %v\n", j.siaDirectory, err)
+		return
+	}
+
+	// Every 20 seconds, check if the balance has exceeded the desiredBalance. If
+	// it has and the miner is running, the miner is throttled. If the desired
+	// balance has not been reached and the miner is not running, the miner is
+	// started.
+	for {
+		select {
+		case <-j.tg.StopChan():
+			return
+		case <-time.After(time.Second * 20):
+		}
+
+		var walletInfo api.WalletGET
+		err = j.client.Get("/wallet", &walletInfo)
+		if err != nil {
+			log.Printf("[%v balanceMaintainer ERROR]: %v\n", j.siaDirectory, err)
+			return
+		}
+
+		haveDesiredBalance := walletInfo.ConfirmedSiacoinBalance.Cmp(desiredBalance) > 0
+		if !minerRunning && !haveDesiredBalance {
+			log.Printf("[%v balanceMaintainer INFO]: not enough currency, starting the miner\n", j.siaDirectory)
+			minerRunning = true
+			if err = j.client.Get("/miner/start", nil); err != nil {
+				log.Printf("[%v miner ERROR]: %v\n", j.siaDirectory, err)
+				return
+			}
+		} else if minerRunning && haveDesiredBalance {
+			log.Printf("[%v balanceMaintainer INFO]: mined enough currency, stopping the miner\n", j.siaDirectory)
+			minerRunning = false
+			if err = j.client.Get("/miner/stop", nil); err != nil {
+				log.Printf("[%v balanceMaintainer ERROR]: %v\n", j.siaDirectory, err)
+				return
+			}
+		}
+	}
+}

--- a/ant/job_host.go
+++ b/ant/job_host.go
@@ -46,7 +46,7 @@ func (j *jobRunner) jobHost() {
 	defer os.RemoveAll(hostdir)
 
 	// Add the storage folder.
-	err := j.client.Post("/host/storage/folders/add", fmt.Sprintf("path=%s&size=30000000000", hostdir), nil)
+	err = j.client.Post("/host/storage/folders/add", fmt.Sprintf("path=%s&size=30000000000", hostdir), nil)
 	if err != nil {
 		log.Printf("[%v jobHost ERROR]: %v\n", j.siaDirectory, err)
 		return

--- a/ant/job_host.go
+++ b/ant/job_host.go
@@ -17,24 +17,12 @@ func (j *jobRunner) jobHost() {
 	j.tg.Add()
 	defer j.tg.Done()
 
-	err := j.client.Post("/wallet/unlock", fmt.Sprintf("encryptionpassword=%s&dictionary=%s", j.walletPassword, "english"), nil)
-	if err != nil {
-		log.Printf("[%v jobHost ERROR: %v\n", j.siaDirectory, err)
-		return
-	}
-
-	err = j.client.Get("/miner/start", nil)
-	if err != nil {
-		log.Printf("[%v jobHost ERROR: %v\n", j.siaDirectory, err)
-		return
-	}
-
 	// Mine at least 50,000 SC
 	desiredbalance := types.NewCurrency64(50000).Mul(types.SiacoinPrecision)
 	success := false
 	for start := time.Now(); time.Since(start) < 5*time.Minute; time.Sleep(time.Second) {
 		var walletInfo api.WalletGET
-		err = j.client.Get("/wallet", &walletInfo)
+		err := j.client.Get("/wallet", &walletInfo)
 		if err != nil {
 			log.Printf("[%v jobHost ERROR]: %v\n", j.siaDirectory, err)
 			return
@@ -58,7 +46,7 @@ func (j *jobRunner) jobHost() {
 	defer os.RemoveAll(hostdir)
 
 	// Add the storage folder.
-	err = j.client.Post("/host/storage/folders/add", fmt.Sprintf("path=%s&size=30000000000", hostdir), nil)
+	err := j.client.Post("/host/storage/folders/add", fmt.Sprintf("path=%s&size=30000000000", hostdir), nil)
 	if err != nil {
 		log.Printf("[%v jobHost ERROR]: %v\n", j.siaDirectory, err)
 		return

--- a/ant/job_miner.go
+++ b/ant/job_miner.go
@@ -1,11 +1,11 @@
 package ant
 
 import (
-	"fmt"
 	"log"
 	"time"
 
 	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/types"
 )
 
 // blockMining unlocks the wallet and mines some currency.  If more than 100
@@ -15,21 +15,18 @@ func (j *jobRunner) blockMining(desiredBalance types.Currency) {
 	j.tg.Add()
 	defer j.tg.Done()
 
-	err = j.client.Get("/miner/start", nil)
+	minerRunning := true
+	err := j.client.Get("/miner/start", nil)
 	if err != nil {
 		log.Printf("[%v blockMining ERROR]: %v\n", j.siaDirectory, err)
 		return
 	}
-
-	var walletInfo api.WalletGET
-	err = j.client.Get("/wallet", &walletInfo)
-	if err != nil {
-		log.Printf("[%v blockMining ERROR]: %v\n", j.siaDirectory, err)
-		return
-	}
-	lastBalance := walletInfo.ConfirmedSiacoinBalance
 
 	// Every 100 seconds, verify that the balance has increased.
+	// if the balance is above desiredBalance, throttle the miner.
+	// if desiredBalance is zero, the miner runs forever.
+	runForever := desiredBalance.Cmp(types.ZeroCurrency) == 0
+
 	for {
 		select {
 		case <-j.tg.StopChan():
@@ -37,15 +34,32 @@ func (j *jobRunner) blockMining(desiredBalance types.Currency) {
 		case <-time.After(time.Second * 100):
 		}
 
+		if runForever {
+			continue
+		}
+
+		var walletInfo api.WalletGET
 		err = j.client.Get("/wallet", &walletInfo)
 		if err != nil {
 			log.Printf("[%v blockMining ERROR]: %v\n", j.siaDirectory, err)
+			return
 		}
-		if walletInfo.ConfirmedSiacoinBalance.Cmp(lastBalance) > 0 {
-			log.Printf("[%v SUCCESS] blockMining job succeeded", j.siaDirectory)
-			lastBalance = walletInfo.ConfirmedSiacoinBalance
-		} else {
-			log.Printf("[%v blockMining ERROR]: it took too long to receive new funds in miner job\n", j.siaDirectory)
+
+		haveDesiredBalance := walletInfo.ConfirmedSiacoinBalance.Cmp(desiredBalance) > 0
+		if !minerRunning && !haveDesiredBalance {
+			log.Printf("[%v miner INFO]: not enough currency, starting the miner\n", j.siaDirectory)
+			minerRunning = true
+			if err = j.client.Get("/miner/start", nil); err != nil {
+				log.Printf("[%v miner ERROR]: %v\n", j.siaDirectory, err)
+				return
+			}
+		} else if minerRunning && haveDesiredBalance {
+			log.Printf("[%v miner INFO]: mined enough currency, stopping the miner\n", j.siaDirectory)
+			minerRunning = false
+			if err = j.client.Get("/miner/stop", nil); err != nil {
+				log.Printf("[%v miner ERROR]: %v\n", j.siaDirectory, err)
+				return
+			}
 		}
 	}
 }

--- a/ant/job_miner.go
+++ b/ant/job_miner.go
@@ -5,61 +5,46 @@ import (
 	"time"
 
 	"github.com/NebulousLabs/Sia/api"
-	"github.com/NebulousLabs/Sia/types"
 )
 
-// blockMining mines blocks until desiredBalance is reached. If desiredBalance
-// is zero, blockMining will start the miner and return, mining indefinitely.
-func (j *jobRunner) blockMining(desiredBalance types.Currency) {
+// blockMining indefinitely mines blocks.  If more than 100
+// seconds passes before the wallet has received some amount of currency, this
+// job will print an error.
+func (j *jobRunner) blockMining() {
 	j.tg.Add()
 	defer j.tg.Done()
 
-	minerRunning := true
 	err := j.client.Get("/miner/start", nil)
 	if err != nil {
 		log.Printf("[%v blockMining ERROR]: %v\n", j.siaDirectory, err)
 		return
 	}
 
-	// If desiredBalance is zero, just return, leaving the miner running.
-	runForever := desiredBalance.Cmp(types.ZeroCurrency) == 0
-	if runForever {
+	var walletInfo api.WalletGET
+	err = j.client.Get("/wallet", &walletInfo)
+	if err != nil {
+		log.Printf("[%v blockMining ERROR]: %v\n", j.siaDirectory, err)
 		return
 	}
+	lastBalance := walletInfo.ConfirmedSiacoinBalance
 
-	// Every 20 seconds, check if the balance has exceeded the desiredBalance. If
-	// it has and the miner is running, the miner is throttled. If the desired
-	// balance has not been reached and the miner is not running, the miner is
-	// started.
+	// Every 100 seconds, verify that the balance has increased.
 	for {
 		select {
 		case <-j.tg.StopChan():
 			return
-		case <-time.After(time.Second * 20):
+		case <-time.After(time.Second * 100):
 		}
 
-		var walletInfo api.WalletGET
 		err = j.client.Get("/wallet", &walletInfo)
 		if err != nil {
 			log.Printf("[%v blockMining ERROR]: %v\n", j.siaDirectory, err)
-			return
 		}
-
-		haveDesiredBalance := walletInfo.ConfirmedSiacoinBalance.Cmp(desiredBalance) > 0
-		if !minerRunning && !haveDesiredBalance {
-			log.Printf("[%v miner INFO]: not enough currency, starting the miner\n", j.siaDirectory)
-			minerRunning = true
-			if err = j.client.Get("/miner/start", nil); err != nil {
-				log.Printf("[%v miner ERROR]: %v\n", j.siaDirectory, err)
-				return
-			}
-		} else if minerRunning && haveDesiredBalance {
-			log.Printf("[%v miner INFO]: mined enough currency, stopping the miner\n", j.siaDirectory)
-			minerRunning = false
-			if err = j.client.Get("/miner/stop", nil); err != nil {
-				log.Printf("[%v miner ERROR]: %v\n", j.siaDirectory, err)
-				return
-			}
+		if walletInfo.ConfirmedSiacoinBalance.Cmp(lastBalance) > 0 {
+			log.Printf("[%v SUCCESS] blockMining job succeeded", j.siaDirectory)
+			lastBalance = walletInfo.ConfirmedSiacoinBalance
+		} else {
+			log.Printf("[%v blockMining ERROR]: it took too long to receive new funds in miner job\n", j.siaDirectory)
 		}
 	}
 }

--- a/ant/job_miner.go
+++ b/ant/job_miner.go
@@ -11,15 +11,9 @@ import (
 // blockMining unlocks the wallet and mines some currency.  If more than 100
 // seconds passes before the wallet has received some amount of currency, this
 // job will print an error.
-func (j *jobRunner) blockMining() {
+func (j *jobRunner) blockMining(desiredBalance types.Currency) {
 	j.tg.Add()
 	defer j.tg.Done()
-
-	err := j.client.Post("/wallet/unlock", fmt.Sprintf("encryptionpassword=%s&dictionary=%s", j.walletPassword, "english"), nil)
-	if err != nil {
-		log.Printf("[%v blockMining ERROR]: %v\n", j.siaDirectory, err)
-		return
-	}
 
 	err = j.client.Get("/miner/start", nil)
 	if err != nil {

--- a/ant/job_renter.go
+++ b/ant/job_renter.go
@@ -45,7 +45,7 @@ const (
 
 	// uploadFileSize defines the size of the test files to be uploaded.  Test
 	// files are filled with random data.
-	uploadFileSize = 10e6
+	uploadFileSize = 1e9
 )
 
 var (

--- a/ant/job_renter.go
+++ b/ant/job_renter.go
@@ -383,18 +383,6 @@ func (j *jobRunner) storageRenter() {
 	j.tg.Add()
 	defer j.tg.Done()
 
-	// Unlock the wallet and begin mining to earn enough coins for uploading.
-	err := j.client.Post("/wallet/unlock", fmt.Sprintf("encryptionpassword=%s&dictionary=%s", j.walletPassword, "english"), nil)
-	if err != nil {
-		log.Printf("[ERROR] [renter] [%v] Trouble when unlocking wallet: %v\n", j.siaDirectory, err)
-		return
-	}
-	err = j.client.Get("/miner/start", nil)
-	if err != nil {
-		log.Printf("[ERROR] [renter] [%v] Trouble when starting the miner: %v\n", j.siaDirectory, err)
-		return
-	}
-
 	// Block until a minimum threshold of coins have been mined.
 	start := time.Now()
 	var walletInfo api.WalletGET
@@ -413,7 +401,7 @@ func (j *jobRunner) storageRenter() {
 		}
 
 		// Update the wallet balance.
-		err = j.client.Get("/wallet", &walletInfo)
+		err := j.client.Get("/wallet", &walletInfo)
 		if err != nil {
 			log.Printf("[ERROR] [renter] [%v] Trouble when calling /wallet: %v\n", j.siaDirectory, err)
 		}

--- a/ant/jobrunner.go
+++ b/ant/jobrunner.go
@@ -28,6 +28,12 @@ func newJobRunner(apiaddr string, authpassword string, siadirectory string) (*jo
 		return nil, err
 	}
 	jr.walletPassword = walletParams.PrimarySeed
+
+	err = j.client.Post("/wallet/unlock", fmt.Sprintf("encryptionpassword=%s&dictionary=%s", j.walletPassword, "english"), nil)
+	if err != nil {
+		return nil, err
+	}
+
 	return jr, nil
 }
 

--- a/ant/jobrunner.go
+++ b/ant/jobrunner.go
@@ -1,6 +1,8 @@
 package ant
 
 import (
+	"fmt"
+
 	"github.com/NebulousLabs/Sia/api"
 	"github.com/NebulousLabs/Sia/sync"
 )
@@ -29,7 +31,7 @@ func newJobRunner(apiaddr string, authpassword string, siadirectory string) (*jo
 	}
 	jr.walletPassword = walletParams.PrimarySeed
 
-	err = j.client.Post("/wallet/unlock", fmt.Sprintf("encryptionpassword=%s&dictionary=%s", j.walletPassword, "english"), nil)
+	err = jr.client.Post("/wallet/unlock", fmt.Sprintf("encryptionpassword=%s&dictionary=%s", jr.walletPassword, "english"), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/sia-antfarm/ant.go
+++ b/sia-antfarm/ant.go
@@ -144,6 +144,17 @@ func parseConfig(config ant.AntConfig) (ant.AntConfig, error) {
 		config.SiadPath = "siad"
 	}
 
+	// DesiredCurrency and `miner` are mutually exclusive.
+	hasMiner := false
+	for _, job := range config.Jobs {
+		if job == "miner" {
+			hasMiner = true
+		}
+	}
+	if hasMiner && config.DesiredCurrency != 0 {
+		return ant.AntConfig{}, errors.New("error parsing config: cannot have desired currency with miner job")
+	}
+
 	// Automatically generate 3 free operating system ports for the Ant's api,
 	// rpc, and host addresses
 	addrs, err := getAddrs(3)


### PR DESCRIPTION
This PR adds a config option, `"DesiredCurrency": int (SC)`, which is input to a `balanceMaintainer` job in `sia-ant`. This job will mine until the `DesiredCurrency` amount exists in the wallet, after which point it stops the miner. If the wallet balance drops below `DesiredCurrency`, `balanceMaintainer` will start the miner again. This should greatly reduce the performance impact of running several renters and hosts.

