### PR TITLE
add wallet `bigsupplier` and `littlespender` jobs

### DIFF
--- a/ant/ant.go
+++ b/ant/ant.go
@@ -1,10 +1,12 @@
 package ant
 
 import (
+	"errors"
 	"log"
 	"net"
 	"os/exec"
 
+	"github.com/NebulousLabs/Sia/api"
 	"github.com/NebulousLabs/Sia/types"
 	"github.com/NebulousLabs/go-upnp"
 )
@@ -26,6 +28,8 @@ type AntConfig struct {
 type Ant struct {
 	APIAddr string
 	RPCAddr string
+
+	Config AntConfig
 
 	siad *exec.Cmd
 	jr   *jobRunner
@@ -114,6 +118,7 @@ func New(config AntConfig) (*Ant, error) {
 	return &Ant{
 		APIAddr: config.APIAddr,
 		RPCAddr: config.RPCAddr,
+		Config:  config,
 
 		siad: siad,
 		jr:   j,
@@ -130,6 +135,33 @@ func (a *Ant) Close() error {
 	return nil
 }
 
+// StartJob starts the job indicated by `job` after an ant has been
+// initialized. Arguments are passed to the job using args.
+func (a *Ant) StartJob(job string, args ...interface{}) error {
+	if a.jr == nil {
+		return errors.New("ant is not running")
+	}
+
+	switch job {
+	case "miner":
+		go a.jr.blockMining()
+	case "host":
+		go a.jr.jobHost()
+	case "renter":
+		go a.jr.storageRenter()
+	case "gateway":
+		go a.jr.gatewayConnectability()
+	case "bigspender":
+		go a.jr.bigSpender()
+	case "littlesupplier":
+		go a.jr.littleSupplier(args[0].(types.UnlockHash))
+	default:
+		return errors.New("no such job")
+	}
+
+	return nil
+}
+
 // BlockHeight returns the highest block height seen by the ant.
 func (a *Ant) BlockHeight() types.BlockHeight {
 	height := types.BlockHeight(0)
@@ -139,4 +171,18 @@ func (a *Ant) BlockHeight() types.BlockHeight {
 		}
 	}
 	return height
+}
+
+// WalletAddress returns a wallet address that this ant can receive coins on.
+func (a *Ant) WalletAddress() (*types.UnlockHash, error) {
+	if a.jr == nil {
+		return nil, errors.New("ant is not running")
+	}
+
+	var addressGet api.WalletAddressGET
+	if err := a.jr.client.Get("/wallet/address", &addressGet); err != nil {
+		return nil, err
+	}
+
+	return &addressGet.Address, nil
 }

--- a/ant/ant_test.go
+++ b/ant/ant_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/types"
 )
 
 func TestNewAnt(t *testing.T) {
@@ -31,5 +32,64 @@ func TestNewAnt(t *testing.T) {
 	c := api.NewClient("localhost:31337", "")
 	if err = c.Get("/consensus", nil); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestStartJob(t *testing.T) {
+	datadir, err := ioutil.TempDir("", "testing-data")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(datadir)
+
+	config := AntConfig{
+		APIAddr:      "localhost:31337",
+		RPCAddr:      "localhost:31338",
+		HostAddr:     "localhost:31339",
+		SiaDirectory: datadir,
+		SiadPath:     "siad",
+	}
+
+	ant, err := New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ant.Close()
+
+	// nonexistent job should throw an error
+	err = ant.StartJob("thisjobdoesnotexist")
+	if err == nil {
+		t.Fatal("StartJob should return an error with a nonexistent job")
+	}
+}
+
+func TestWalletAddress(t *testing.T) {
+	datadir, err := ioutil.TempDir("", "testing-data")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(datadir)
+
+	config := AntConfig{
+		APIAddr:      "localhost:31337",
+		RPCAddr:      "localhost:31338",
+		HostAddr:     "localhost:31339",
+		SiaDirectory: datadir,
+		SiadPath:     "siad",
+	}
+
+	ant, err := New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ant.Close()
+
+	addr, err := ant.WalletAddress()
+	if err != nil {
+		t.Fatal(err)
+	}
+	blankaddr := types.UnlockHash{}
+	if *addr == blankaddr {
+		t.Fatal("WalletAddress returned an empty address")
 	}
 }

--- a/ant/job_wallet_bigspender.go
+++ b/ant/job_wallet_bigspender.go
@@ -1,0 +1,49 @@
+package ant
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+var (
+	spendInterval  = time.Second * 30
+	spendThreshold = types.NewCurrency64(5e4).Mul(types.SiacoinPrecision)
+)
+
+func (j *jobRunner) bigSpender() {
+	j.tg.Add()
+	defer j.tg.Done()
+
+	for {
+		select {
+		case <-j.tg.StopChan():
+			return
+		case <-time.After(spendInterval):
+		}
+
+		var walletGet api.WalletGET
+		if err := j.client.Get("/wallet", &walletGet); err != nil {
+			log.Printf("[%v jobSpender ERROR]: %v\n", j.siaDirectory, err)
+			return
+		}
+
+		if walletGet.ConfirmedSiacoinBalance.Cmp(spendThreshold) < 0 {
+			continue
+		}
+
+		log.Printf("[%v jobSpender INFO]: sending a large transaction\n", j.siaDirectory)
+
+		voidaddress := types.UnlockHash{}
+		err := j.client.Post("/wallet/siacoins", fmt.Sprintf("amount=%v&destination=%v", spendThreshold, voidaddress), nil)
+		if err != nil {
+			log.Printf("[%v jobSpender ERROR]: %v\n", j.siaDirectory, err)
+			continue
+		}
+
+		log.Printf("[%v jobSpender INFO]: large transaction send successful\n", j.siaDirectory)
+	}
+}

--- a/ant/job_wallet_littlesupplier.go
+++ b/ant/job_wallet_littlesupplier.go
@@ -1,0 +1,43 @@
+package ant
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+var (
+	sendInterval = time.Second * 2
+	sendAmount   = types.NewCurrency64(1000).Mul(types.SiacoinPrecision)
+)
+
+func (j *jobRunner) littleSupplier(sendAddress types.UnlockHash) {
+	j.tg.Add()
+	defer j.tg.Done()
+
+	for {
+		select {
+		case <-j.tg.StopChan():
+			return
+		case <-time.After(sendInterval):
+		}
+
+		var walletGet api.WalletGET
+		if err := j.client.Get("/wallet", &walletGet); err != nil {
+			log.Printf("[%v jobSpender ERROR]: %v\n", j.siaDirectory, err)
+			return
+		}
+
+		if walletGet.ConfirmedSiacoinBalance.Cmp(sendAmount) < 0 {
+			continue
+		}
+
+		err := j.client.Post("/wallet/siacoins", fmt.Sprintf("amount=%v&destination=%v", sendAmount, sendAddress), nil)
+		if err != nil {
+			log.Printf("[%v jobSupplier ERROR]: %v\n", j.siaDirectory, err)
+		}
+	}
+}

--- a/sia-antfarm/antfarm.go
+++ b/sia-antfarm/antfarm.go
@@ -52,6 +52,12 @@ func createAntfarm(config AntfarmConfig) (*antFarm, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	err = startJobs(ants...)
+	if err != nil {
+		return nil, err
+	}
+
 	farm.ants = ants
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
This PR adds the `bigsupplier` and `littlespender` wallet jobs, used to simulate heavily fragmented wallets like the ones used by Poloniex.

There is some ugly code here, since one job requires data (wallet addresses) only available once the other job starts. This logic is handled by the new `startJobs` func.