### PR TITLE
add support for custom ant names

### DIFF
--- a/ant/ant.go
+++ b/ant/ant.go
@@ -16,6 +16,7 @@ type AntConfig struct {
 	RPCAddr         string `json:",omitempty"`
 	HostAddr        string `json:",omitempty"`
 	SiaDirectory    string `json:",omitempty"`
+	Name            string `json:",omitempty"`
 	SiadPath        string
 	Jobs            []string
 	DesiredCurrency uint64

--- a/nebulous-configs/basic-renter-host.json
+++ b/nebulous-configs/basic-renter-host.json
@@ -8,24 +8,28 @@
 			]
 		},
 		{
+			"Name": "host1",
 			"jobs": [
 				"host"
 			],
 			"desiredcurrency": 100000
 		},
 		{
+			"Name": "host2",
 			"jobs": [
 				"host"
 			],
 			"desiredcurrency": 100000
 		},
 		{
+			"Name": "host3",
 			"jobs": [
 				"host"
 			],
 			"desiredcurrency": 100000
 		},
 		{
+			"Name": "renter",
 			"jobs": [
 				"renter"
 			],

--- a/sia-antfarm/ant.go
+++ b/sia-antfarm/ant.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"os"
 
 	"github.com/NebulousLabs/Sia-Ant-Farm/ant"
 	"github.com/NebulousLabs/Sia/api"
@@ -33,7 +34,7 @@ func getAddrs(n int) ([]string, error) {
 // effectively bootstrapping the antfarm.
 func connectAnts(ants ...*ant.Ant) error {
 	if len(ants) < 2 {
-		return errors.New("you must call connectAnts with at least two ants.")
+		return errors.New("you must call connectAnts with at least two ants")
 	}
 	targetAnt := ants[0]
 	c := api.NewClient(targetAnt.APIAddr, "")
@@ -132,12 +133,21 @@ func startAnts(configs ...ant.AntConfig) ([]*ant.Ant, error) {
 func parseConfig(config ant.AntConfig) (ant.AntConfig, error) {
 	// if config.SiaDirectory isn't set, use ioutil.TempDir to create a new
 	// temporary directory.
-	if config.SiaDirectory == "" {
+	if config.SiaDirectory == "" && config.Name == "" {
 		tempdir, err := ioutil.TempDir("./antfarm-data", "ant")
 		if err != nil {
 			return ant.AntConfig{}, err
 		}
 		config.SiaDirectory = tempdir
+	}
+
+	if config.Name != "" {
+		siadir := fmt.Sprintf("./antfarm-data/%v", config.Name)
+		err := os.Mkdir(siadir, 0755)
+		if err != nil {
+			return ant.AntConfig{}, err
+		}
+		config.SiaDirectory = siadir
 	}
 
 	if config.SiadPath == "" {

--- a/sia-antfarm/antfarm.go
+++ b/sia-antfarm/antfarm.go
@@ -16,6 +16,7 @@ type (
 	// AntfarmConfig contains the fields to parse and use to create a sia-antfarm.
 	AntfarmConfig struct {
 		ListenAddress string
+		DataDirPrefix string
 		AntConfigs    []ant.AntConfig
 		AutoConnect   bool
 
@@ -42,8 +43,13 @@ type (
 // createAntfarm creates a new antFarm given the supplied AntfarmConfig
 func createAntfarm(config AntfarmConfig) (*antFarm, error) {
 	// clear old antfarm data before creating an antfarm
-	os.RemoveAll("./antfarm-data")
-	os.MkdirAll("./antfarm-data", 0700)
+	datadir := "./antfarm-data"
+	if config.DataDirPrefix != "" {
+		datadir = config.DataDirPrefix
+	}
+
+	os.RemoveAll(datadir)
+	os.MkdirAll(datadir, 0700)
 
 	farm := &antFarm{}
 

--- a/sia-antfarm/antfarm_test.go
+++ b/sia-antfarm/antfarm_test.go
@@ -64,6 +64,7 @@ func TestConnectExternalAntfarm(t *testing.T) {
 
 	config1 := AntfarmConfig{
 		ListenAddress: "127.0.0.1:31337",
+		DataDirPrefix: "antfarm-data1",
 		AntConfigs: []ant.AntConfig{
 			{
 				RPCAddr: "127.0.0.1:3337",
@@ -76,6 +77,7 @@ func TestConnectExternalAntfarm(t *testing.T) {
 
 	config2 := AntfarmConfig{
 		ListenAddress: "127.0.0.1:31338",
+		DataDirPrefix: "antfarm-data2",
 		AntConfigs: []ant.AntConfig{
 			{
 				RPCAddr: "127.0.0.1:3338",


### PR DESCRIPTION
This is a minor usability improvement that adds support for custom ant names, so it's easier to tell which data directories go with which ants.