### PR TITLE
add --modules flag to run required modules in antfarm

### DIFF
--- a/ant/siad.go
+++ b/ant/siad.go
@@ -31,7 +31,7 @@ func newSiad(siadPath string, datadir string, apiAddr string, rpcAddr string, ho
 	if err != nil {
 		return nil, err
 	}
-	cmd := exec.Command(siadPath, "--no-bootstrap", "--sia-directory="+datadir, "--api-addr="+apiAddr, "--rpc-addr="+rpcAddr, "--host-addr="+hostAddr)
+	cmd := exec.Command(siadPath, "--modules=cgthmrw", "--no-bootstrap", "--sia-directory="+datadir, "--api-addr="+apiAddr, "--rpc-addr="+rpcAddr, "--host-addr="+hostAddr)
 	cmd.Stderr = logfile
 	cmd.Stdout = logfile
 


### PR DESCRIPTION
A recent change to Siad removed the miner module from the list of defaults, which is a problem since the miner is a required module for the antfarm. I added a `--modules` flag to the ants which starts each ant with a consensus set, gateway, tpool, host, miner, renter, and wallet.