### PR TITLE
add testing-stub.json: example config for a stub network

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ os:
   - linux
 
 go:
-  - 1.6
+  - 1.8
 
 install:
   make dependencies

--- a/nebulous-configs/testing-stub.json
+++ b/nebulous-configs/testing-stub.json
@@ -1,0 +1,31 @@
+{
+	"antconfigs": 
+	[ 
+		{
+			"APIAddr": "localhost:9980",
+			"jobs": [
+				"gateway",
+				"miner"
+			]
+		},
+		{
+			"jobs": [
+				"host"
+			],
+			"desiredcurrency": 100000
+		},
+		{
+			"jobs": [
+				"host"
+			],
+			"desiredcurrency": 100000
+		},
+		{
+			"jobs": [
+				"host"
+			],
+			"desiredcurrency": 100000
+		}
+	],
+	"autoconnect": true
+}


### PR DESCRIPTION
This PR adds a new config `testing-stub.json`, useful for devs who want to spin up an antfarm in order to test some functionality that requires a Sia network.