### PR TITLE
Made the renter job upload behave better on Windows

### DIFF
--- a/ant/job_renter.go
+++ b/ant/job_renter.go
@@ -320,7 +320,11 @@ func (r *renterJob) upload() error {
 
 	// use the sourcePath with its leading slash stripped for the sia path
 	siapath := sourcePath[1:]
-
+	if(string(sourcePath[1]) == ":") {
+		// looks like a Windows path - Cut Differently!
+		siapath = sourcePath[3:]
+	} 
+	
 	// Add the file to the renter.
 	rf := renterFile{
 		merkleRoot: merkleRoot,


### PR DESCRIPTION
File upload did assume that a path always starts with a slash. 