### PR TITLE
Update api path to node/api

### DIFF
--- a/ant/ant.go
+++ b/ant/ant.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"os/exec"
 
-	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/node/api"
 	"github.com/NebulousLabs/Sia/types"
 	"github.com/NebulousLabs/go-upnp"
 )

--- a/ant/ant_test.go
+++ b/ant/ant_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/node/api"
 	"github.com/NebulousLabs/Sia/types"
 )
 

--- a/ant/job_balancemaintainer.go
+++ b/ant/job_balancemaintainer.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/node/api"
 	"github.com/NebulousLabs/Sia/types"
 )
 

--- a/ant/job_gateway.go
+++ b/ant/job_gateway.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/node/api"
 )
 
 // gatewayConnectability will print an error to the log if the node has zero

--- a/ant/job_host.go
+++ b/ant/job_host.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/NebulousLabs/Sia/api"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/node/api"
 	"github.com/NebulousLabs/Sia/types"
 )
 

--- a/ant/job_miner.go
+++ b/ant/job_miner.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/node/api"
 )
 
 // blockMining indefinitely mines blocks.  If more than 100

--- a/ant/job_renter.go
+++ b/ant/job_renter.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/NebulousLabs/merkletree"
 
-	"github.com/NebulousLabs/Sia/api"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/node/api"
 	"github.com/NebulousLabs/Sia/types"
 	"github.com/NebulousLabs/fastrand"
 )
@@ -320,11 +320,11 @@ func (r *renterJob) upload() error {
 
 	// use the sourcePath with its leading slash stripped for the sia path
 	siapath := sourcePath[1:]
-	if(string(sourcePath[1]) == ":") {
+	if string(sourcePath[1]) == ":" {
 		// looks like a Windows path - Cut Differently!
 		siapath = sourcePath[3:]
-	} 
-	
+	}
+
 	// Add the file to the renter.
 	rf := renterFile{
 		merkleRoot: merkleRoot,

--- a/ant/job_wallet_bigspender.go
+++ b/ant/job_wallet_bigspender.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/node/api"
 	"github.com/NebulousLabs/Sia/types"
 )
 

--- a/ant/job_wallet_littlesupplier.go
+++ b/ant/job_wallet_littlesupplier.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/node/api"
 	"github.com/NebulousLabs/Sia/types"
 )
 

--- a/ant/jobrunner.go
+++ b/ant/jobrunner.go
@@ -3,7 +3,7 @@ package ant
 import (
 	"fmt"
 
-	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/node/api"
 	"github.com/NebulousLabs/Sia/sync"
 )
 

--- a/ant/siad.go
+++ b/ant/siad.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/node/api"
 )
 
 // newSiad spawns a new siad process using os/exec and waits for the api to

--- a/ant/siad_test.go
+++ b/ant/siad_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/node/api"
 )
 
 // TestNewSiad tests that NewSiad creates a reachable Sia API

--- a/sia-antfarm/ant.go
+++ b/sia-antfarm/ant.go
@@ -8,8 +8,8 @@ import (
 	"os"
 
 	"github.com/NebulousLabs/Sia-Ant-Farm/ant"
-	"github.com/NebulousLabs/Sia/api"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/node/api"
 	"github.com/NebulousLabs/Sia/types"
 )
 

--- a/sia-antfarm/ant_test.go
+++ b/sia-antfarm/ant_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/NebulousLabs/Sia-Ant-Farm/ant"
-	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/node/api"
 )
 
 // TestStartAnts verifies that startAnts successfully starts ants given some

--- a/sia-antfarm/antfarm_test.go
+++ b/sia-antfarm/antfarm_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/NebulousLabs/Sia-Ant-Farm/ant"
-	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/node/api"
 )
 
 // verify that createAntfarm() creates a new antfarm correctly.


### PR DESCRIPTION
The import path of `api` has changed when referencing https://github.com/NebulousLabs/Sia. This PR simply updates the `api` path to `node/api`.