### PR TITLE
Update golint package location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ dependencies:
 	go get -u github.com/NebulousLabs/Sia/...
 	go install -tags='dev' github.com/NebulousLabs/Sia/cmd/siad
 	go install -race std
-	go get -u github.com/golang/lint/golint
+	go get -u golang.org/x/lint/golint
 
 pkgs = ./sia-antfarm ./ant
 


### PR DESCRIPTION
The golint package location was [changed back in February](https://github.com/golang/lint/commit/ead987a65e5c7e053cf9633f9eac1f734f6b4fe3). This pull request updates the Makefile to reflect the updated location. 